### PR TITLE
:ambulance: Add conditional check for Authorization header

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ const client = jwksClient({ jwksUri });
 
 const verify = (req) => {
   try {
-    const [bearer, token] = get(req, "headers.Authorization").split(" ");
+    const authorization = get(req, "headers.authorization") || get(req, "headers.Authorization");
+    const [bearer, token] = authorization.split(" ");
     if (bearer !== "Bearer") throw Error("Bearer prefix missing.");
     if (!token) throw Error("Token undefined.");
     return verifyJwt(token);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pointblankdev/lambda-auth",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "Lambda authorization for JWTs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When the request comes in right now, for some reason, the authorization header lives within `authorization` and not `Authorization`, so the code breaks at that point.

This fix checks for both to see which one contains the authorization token and appends it accordingly